### PR TITLE
Fix an installation problem (ModuleNotFoundError)

### DIFF
--- a/labs/environment_spatial2022.yml
+++ b/labs/environment_spatial2022.yml
@@ -21,7 +21,9 @@ dependencies:
   - python=3.9
   - tree
   - compilers
-  - notebook
+  # pinned due to an incompatibility with jupyter_highlight_selected_word,
+  # which is a dependency of jupyter_contrib_nbextensions
+  - notebook<7
   - jupyter_contrib_nbextensions
   - jupyter_client
   - nbconvert


### PR DESCRIPTION
Trying to install the environment gives a long string of error messages like this (excerpt):

```
Traceback (most recent call last):
  File ".../.conda/envs/tmp/lib/python3.9/site-packages/jupyter_contrib_core/notebook_compat/nbextensions.py", line 6, in <module>
    from notebook.extensions import BaseExtensionApp
ModuleNotFoundError: No module named 'notebook.extensions'

During handling of the above exception, another exception occurred:
```

This comes from an incompatibility of jupyter_contrib_nbextensions with Jupyter notebook 7 and later. This can be worked around by restricting the Jupyter version to <7.

CC @olgadet